### PR TITLE
Passemarche/sync doc 2026 06 24

### DIFF
--- a/passemarche/docs/03_flux_acheteur.md
+++ b/passemarche/docs/03_flux_acheteur.md
@@ -57,7 +57,10 @@ Content-Type: application/json
 {
   "public_market": {
     "name": "Fourniture de matériel informatique pour les services municipaux",
-    "lot_name": "Lot 1 - Ordinateurs portables et stations de travail",
+    "lots": [
+      {"name": "Lot 1 - Ordinateurs portables et stations de travail", "cpv_code": "30213100-6", "lot_type_code": "supplies"},
+      {"name": "Lot 2 - Serveurs et infrastructure réseau", "lot_type_code": "services"}
+    ],
     "deadline": "2024-06-15T23:59:59Z",
     "siret": "13002526500013",
     "market_type_codes": ["supplies", "services"]
@@ -73,7 +76,15 @@ Content-Type: application/json
 | `deadline`          | datetime | Date limite de candidature       | Requis, format ISO 8601                         |
 | `siret`             | string   | SIRET de l'organisation publique | Requis, exactement 14 chiffres, validation Luhn |
 | `market_type_codes` | array    | Types de marché                  | Requis, minimum 1 élément                       |
-| `lot_name`          | string   | Nom du lot spécifique            | Optionnel, max 255 caractères                   |
+| `lots`              | array    | Liste des lots du marché         | Optionnel, chaque lot requiert un `name`        |
+
+**Propriétés d'un lot**
+
+| Champ           | Type   | Requis | Description           | Contraintes                                                                        |
+| --------------- | ------ | ------ | --------------------- | ---------------------------------------------------------------------------------- |
+| `name`          | string | Oui    | Nom du lot            | Max 255 caractères                                                                 |
+| `cpv_code`      | string | Non    | Code CPV du lot       | Format `XXXXXXXX-X` (8 chiffres, tiret, 1 chiffre)                                |
+| `lot_type_code` | string | Non    | Type de marché du lot | `supplies`, `services`, `works` — si absent, hérite du premier `market_type_codes` |
 
 #### Codes de Types de Marché
 
@@ -147,6 +158,24 @@ Une fois le marché créé, la plateforme de marchés publics redirige l'acheteu
 
 **Note** : Le SIRET de l'organisation publique est requis pour la conformité avec l'API Entreprise
 
+#### Étape 1b : Configuration des types de lots (marché hétérogène)
+
+Pour les marchés comportant plusieurs lots, l'acheteur peut affiner le type de marché par lot via l'interface. L'éditeur peut aussi pré-renseigner un type par lot à la création (champ `market_type_code` non supporté côté API — le type par lot est défini uniquement via l'interface acheteur).
+
+**Endpoint de modification des types de lots**
+
+`PATCH /buyer/public_markets/{identifier}/lots`
+
+| Paramètre        | Type    | Description                              |
+| ---------------- | ------- | ---------------------------------------- |
+| `market_type_id` | integer | ID interne du type de marché à appliquer |
+| `lot_ids[]`      | array   | IDs des lots à modifier                  |
+
+**Comportement** :
+* Si le type sélectionné est identique au `platform_market_type` du lot (type transmis par l'éditeur à la création), l'override est annulé et le lot reprend le type de la plateforme.
+* Chaque lot conserve deux types distincts : `platform_market_type` (source éditeur, non modifiable) et `market_type` (override acheteur, optionnel).
+* Le type effectif (`effective_market_type`) est `market_type` s'il est défini, sinon `platform_market_type`.
+
 #### Étape 2 : Champs Obligatoires
 
 * **URL** : `/buyer/public_markets/{identifier}/required_fields`
@@ -209,7 +238,10 @@ Le webhook est automatiquement déclenché lors de la finalisation du marché et
   "market": {
     "identifier": "VR-2024-A1B2C3D4E5F6",
     "name": "Fourniture de matériel informatique pour les services municipaux",
-    "lot_name": "Lot 1 - Ordinateurs portables et stations de travail",
+    "lots": [
+      {"id": 1, "name": "Lot 1 - Ordinateurs portables et stations de travail", "cpv_code": "30213100-6", "market_type_code": "supplies"},
+      {"id": 2, "name": "Lot 2 - Serveurs et infrastructure réseau", "market_type_code": "services"}
+    ],
     "deadline": "2024-06-15T23:59:59Z",
     "market_type_codes": ["supplies", "services"],
     "completed_at": "2024-06-15T14:30:45Z",
@@ -227,13 +259,14 @@ Le webhook est automatiquement déclenché lors de la finalisation du marché et
 
 #### Paramètres du Payload
 
-| Champ                 | Description                           |
-| --------------------- | ------------------------------------- |
-| `event`               | Type d'événement (`market.completed`) |
-| `timestamp`           | Horodatage ISO 8601 de l'événement    |
-| `market.identifier`   | Identifiant unique du marché          |
-| `market.field_keys`   | Liste des clés des champs configurés  |
-| `market.completed_at` | Date/heure de complétion              |
+| Champ                 | Description                                                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `event`               | Type d'événement (`market.completed`)                                                                                                        |
+| `timestamp`           | Horodatage ISO 8601 de l'événement                                                                                                           |
+| `market.identifier`   | Identifiant unique du marché                                                                                                                 |
+| `market.lots`         | Liste des lots triés par position (`id`, `name`, `cpv_code`, `market_type_code`) — `cpv_code` et `market_type_code` absents si non renseignés |
+| `market.field_keys`   | Liste des clés des champs configurés                                                                                                         |
+| `market.completed_at` | Date/heure de complétion                                                                                                                     |
 
 #### Sécurité du Webhook
 

--- a/passemarche/docs/05_reference_api.md
+++ b/passemarche/docs/05_reference_api.md
@@ -156,7 +156,10 @@ Content-Type: application/json
 {
   "public_market": {
     "name": "Fourniture de matériel informatique",
-    "lot_name": "Lot 1 - Ordinateurs portables",
+    "lots": [
+      {"name": "Lot 1 - Ordinateurs portables", "cpv_code": "30213100-6", "lot_type_code": "supplies"},
+      {"name": "Lot 2 - Serveurs et infrastructure", "lot_type_code": "services"}
+    ],
     "deadline": "2024-12-31T23:59:59Z",
     "siret": "13002526500013",
     "market_type_codes": ["supplies", "services"],
@@ -173,8 +176,16 @@ Content-Type: application/json
 | `deadline`          | datetime | Oui    | Date limite candidature                                         | Format ISO 8601, futur            |
 | `siret`             | string   | Oui    | SIRET de l'organisation publique (14 chiffres, validation Luhn) | Exactement 14 chiffres numériques |
 | `market_type_codes` | array    | Oui    | Types de marché                                                 | Au moins 1 élément                |
-| `lot_name`          | string   | Non    | Nom du lot spécifique                                           | Max 255 caractères                |
+| `lots`              | array    | Non    | Liste des lots du marché                                        | Chaque lot requiert un `name`     |
 | `provider_user_id`  | string   | Non    | Identifiant de l'utilisateur côté éditeur (acheteur)            | Max 255 caractères                |
+
+**Propriétés d'un lot**
+
+| Champ           | Type   | Requis | Description           | Contraintes                                                                        |
+| --------------- | ------ | ------ | --------------------- | ---------------------------------------------------------------------------------- |
+| `name`          | string | Oui    | Nom du lot            | Max 255 caractères                                                                 |
+| `cpv_code`      | string | Non    | Code CPV du lot       | Format `XXXXXXXX-X` (8 chiffres, tiret, 1 chiffre)                                |
+| `lot_type_code` | string | Non    | Type de marché du lot | `supplies`, `services`, `works` — si absent, hérite du premier `market_type_codes` |
 
 **Types de Marché Valides**
 
@@ -224,6 +235,70 @@ Content-Type: application/json
 {
   "errors": {
     "siret": ["Le numéro de SIRET saisi est invalide ou non reconnu"]
+  }
+}
+```
+
+#### Mettre à jour la DLRO d'un Marché
+
+Mise à jour de la date limite de remise des offres (DLRO) d'un marché existant. Chaque modification est historisée (ancienne valeur, nouvelle valeur, horodatage).
+
+**`PATCH /api/v1/public_markets/{identifier}`**
+
+**En-têtes** :
+
+```http
+Authorization: Bearer {access_token}
+Content-Type: application/json
+```
+
+**Paramètres de chemin**
+
+| Paramètre    | Type   | Description                                   |
+| ------------ | ------ | --------------------------------------------- |
+| `identifier` | string | Identifiant du marché (format VR-YYYY-XXXXXX) |
+
+**Corps de Requête** :
+
+```json
+{
+  "public_market": {
+    "deadline": "2025-03-31T17:00:00Z"
+  }
+}
+```
+
+**Paramètres**
+
+| Champ      | Type     | Requis | Description          | Contraintes     |
+| ---------- | -------- | ------ | -------------------- | --------------- |
+| `deadline` | datetime | Oui    | Nouvelle date limite | Format ISO 8601 |
+
+**Réponse de Succès (200)**
+
+```json
+{
+  "identifier": "VR-2024-A1B2C3D4E5F6",
+  "deadline": "2025-03-31T17:00:00Z"
+}
+```
+
+**Réponses d'Erreur**
+
+**404 - Marché non trouvé ou n'appartient pas à l'éditeur** :
+
+```json
+{
+  "error": "Resource not found"
+}
+```
+
+**422 - Deadline manquante** :
+
+```json
+{
+  "errors": {
+    "deadline": ["doit être rempli(e)"]
   }
 }
 ```

--- a/passemarche/docs/99_scripts_reference.md
+++ b/passemarche/docs/99_scripts_reference.md
@@ -262,7 +262,7 @@ create_market() {
   local market_data='{
     "public_market": {
       "name": "Test - Fourniture équipements informatiques",
-      "lot_name": "Lot unique - Ordinateurs",
+      "lots": [{"name": "Lot unique - Ordinateurs"}],
       "deadline": "2024-12-31T23:59:59Z",
       "siret": "13002526500013",
       "market_type_codes": ["supplies"]
@@ -709,3 +709,33 @@ test_connectivity() {
 ***
 
 Ces scripts sont fournis comme utilitaires complémentaires. Adaptez-les selon vos besoins spécifiques et votre environnement de production.
+
+***
+
+## Scripts internes — Test et QA
+
+### Créer un marché de test avec 1000 lots
+
+Simule un marché créé via l'API avec 1000 lots typés (fournitures, services, travaux). Utile pour tester l'UI de sélection de lots sous charge.
+
+**Disponible en :** development, sandbox, staging uniquement.
+
+```bash
+bin/rails runner script/seed_market_1000_lots.rb
+```
+
+Le script :
+- Crée un nouveau marché `[TEST] Marché 1000 lots` à chaque exécution
+- Génère 1000 lots avec `platform_market_type` rempli (comme un vrai marché créé via API)
+- Enregistre le marché dans la base SQLite du fake editor (dashboard acheteur)
+- Affiche l'identifier à utiliser dans le fake editor
+
+**Exemple de sortie :**
+```
+📋 1000 lots generated
+✅ Market: [TEST] Marché 1000 lots (VR-2026-00XXXXX)
+✅ 1000 lots created
+✅ Market registered in fake editor DB
+
+🎯 Identifier : VR-2026-00XXXXX
+```


### PR DESCRIPTION
Synchronisation des modifications récentes de la documentation Passe Marché :

- Remplacement de lot_name par le tableau lots (avec name, cpv_code, lot_type_code) dans la référence API et le flux acheteur
- Ajout de l'endpoint PATCH /api/v1/public_markets/{identifier} pour mettre à jour la DLRO
- Ajout de l'étape 1b sur la configuration des types de lots pour les marchés hétérogènes
- Enrichissement du payload webhook avec le champ lots
- Ajout du script de test seed_market_1000_lots